### PR TITLE
[astra-types] Implement PolicyDecision and RunReport schemas (#9)

### DIFF
--- a/crates/astra-types/src/id.rs
+++ b/crates/astra-types/src/id.rs
@@ -531,6 +531,14 @@ define_uuid_id!(
     ContextId
 );
 
+define_uuid_id!(
+    /// Unique identifier for a policy decision.
+    ///
+    /// Auto-generated as UUID v4. Records each policy evaluation (allow/deny/escalate)
+    /// for audit trail and compliance.
+    DecisionId
+);
+
 // ============================================================================
 // String-based ID types
 // ============================================================================

--- a/crates/astra-types/src/lib.rs
+++ b/crates/astra-types/src/lib.rs
@@ -35,7 +35,9 @@ mod error;
 mod id;
 mod model;
 mod outcome;
+mod policy;
 mod profile;
+mod report;
 mod sensitive;
 mod task;
 mod time;
@@ -52,14 +54,17 @@ pub use error::{
     AstraError, BoxedError, BudgetType, ErrorContext, ErrorContextBuilder, Result, Severity,
 };
 pub use id::{
-    ArtifactId, CapabilityId, ContextId, CorrelationId, PolicyId, ProfileId, TaskId, WorkspaceId,
-    CAPABILITY_ID_MAX_LEN, POLICY_ID_MAX_LEN, PROFILE_ID_MAX_LEN, WORKSPACE_ID_MAX_LEN,
+    ArtifactId, CapabilityId, ContextId, CorrelationId, DecisionId, PolicyId, ProfileId, TaskId,
+    WorkspaceId, CAPABILITY_ID_MAX_LEN, POLICY_ID_MAX_LEN, PROFILE_ID_MAX_LEN,
+    WORKSPACE_ID_MAX_LEN,
 };
 pub use model::{
     InferenceParams, Message, ModelInvocation, ModelResult, Role, StopReason, Tool, ToolCall, Usage,
 };
 pub use outcome::{Outcome, OutcomeError, OutcomeMetrics, OutcomeStatus};
+pub use policy::{PolicyDecision, PolicyEffect, PolicyLevel, PolicySource};
 pub use profile::{profiles, AgentProfile, CapabilityRef, SandboxTier};
+pub use report::{BudgetSnapshot, Intervention, RunReport, TimelineEvent};
 pub use sensitive::Sensitive;
 pub use task::{Budget, Constraints, TaskEnvelope, TaskEnvelopeBuilder};
 pub use time::Timestamp;

--- a/crates/astra-types/src/policy.rs
+++ b/crates/astra-types/src/policy.rs
@@ -1,0 +1,909 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! PolicyDecision — recorded policy evaluations for audit and compliance.
+//!
+//! Every policy evaluation (allow, deny, escalate) is recorded as a `PolicyDecision`
+//! with full context for audit trail, compliance reporting, and policy tuning.
+//!
+//! # Design
+//!
+//! - Every decision is recorded, including allows (needed for audit completeness)
+//! - Hierarchical policy source tracks which level (global/domain/capability/session)
+//! - Correlation ID links decisions to the originating run/task
+//! - Evaluation duration enables performance monitoring of policy checks
+//!
+//! # Example
+//!
+//! ```
+//! use astra_types::{PolicyDecision, PolicyEffect, PolicyLevel, PolicySource};
+//!
+//! let source = PolicySource::new("rule-001", PolicyLevel::Global);
+//!
+//! // Allow decision
+//! let allow = PolicyDecision::allow("file.read", "agent-123", source.clone());
+//! assert!(!allow.is_denied());
+//!
+//! // Deny decision
+//! let deny = PolicyDecision::deny(
+//!     "network.egress",
+//!     "agent-456",
+//!     source,
+//!     "Egress not permitted at Tier 1",
+//! );
+//! assert!(deny.is_denied());
+//! ```
+
+use std::collections::HashMap;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::{AstraError, ErrorContext};
+use crate::id::{CorrelationId, DecisionId};
+use crate::time::Timestamp;
+use crate::validate::Validate;
+
+// ============================================================================
+// PolicyEffect
+// ============================================================================
+
+/// Result of a policy evaluation.
+///
+/// Three outcomes are possible:
+/// - `Allow`: Action proceeds
+/// - `Deny`: Action is blocked
+/// - `Escalate`: Action requires human approval before proceeding
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PolicyEffect {
+    /// Action is allowed to proceed.
+    Allow,
+    /// Action is denied.
+    Deny,
+    /// Action requires escalation to human operator for approval.
+    Escalate,
+}
+
+impl Default for PolicyEffect {
+    fn default() -> Self {
+        Self::Deny
+    }
+}
+
+impl fmt::Display for PolicyEffect {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Allow => write!(f, "Allow"),
+            Self::Deny => write!(f, "Deny"),
+            Self::Escalate => write!(f, "Escalate"),
+        }
+    }
+}
+
+impl PolicyEffect {
+    /// Check if this effect blocks the action.
+    pub fn is_denied(&self) -> bool {
+        matches!(self, Self::Deny)
+    }
+
+    /// Check if this effect allows the action.
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, Self::Allow)
+    }
+
+    /// Check if this effect requires escalation.
+    pub fn requires_escalation(&self) -> bool {
+        matches!(self, Self::Escalate)
+    }
+}
+
+// ============================================================================
+// PolicyLevel
+// ============================================================================
+
+/// Hierarchy level where a policy rule is defined.
+///
+/// Rules at higher levels (lower in the enum) override rules at lower levels.
+/// Order from most general to most specific: Global < Domain < Capability < Session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PolicyLevel {
+    /// Organization-wide policies applying to all agents and capabilities.
+    Global,
+    /// Domain-specific policies (e.g., "security", "compliance").
+    Domain,
+    /// Capability-specific policies (e.g., "repo.write" restrictions).
+    Capability,
+    /// Session-specific overrides for a single run.
+    Session,
+}
+
+impl Default for PolicyLevel {
+    fn default() -> Self {
+        Self::Global
+    }
+}
+
+impl fmt::Display for PolicyLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Global => write!(f, "Global"),
+            Self::Domain => write!(f, "Domain"),
+            Self::Capability => write!(f, "Capability"),
+            Self::Session => write!(f, "Session"),
+        }
+    }
+}
+
+impl PolicyLevel {
+    /// Check if this level overrides another.
+    ///
+    /// More specific levels (Session > Capability > Domain > Global) override
+    /// more general levels.
+    pub fn overrides(&self, other: PolicyLevel) -> bool {
+        *self > other
+    }
+}
+
+// ============================================================================
+// PolicySource
+// ============================================================================
+
+/// Source of a policy rule.
+///
+/// Tracks provenance: which rule triggered the decision, at what level,
+/// and optionally where the rule is defined.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicySource {
+    /// Rule identifier (e.g., "rule-001", "sandbox-tier-check").
+    pub rule_id: String,
+
+    /// Hierarchy level where the rule is defined.
+    pub level: PolicyLevel,
+
+    /// Optional file/config path where rule is defined.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+impl PolicySource {
+    /// Create a new policy source.
+    pub fn new(rule_id: impl Into<String>, level: PolicyLevel) -> Self {
+        Self {
+            rule_id: rule_id.into(),
+            level,
+            path: None,
+        }
+    }
+
+    /// Set the path where the rule is defined.
+    pub fn with_path(mut self, path: impl Into<String>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+}
+
+impl fmt::Display for PolicySource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}@{}", self.rule_id, self.level)
+    }
+}
+
+impl Validate for PolicySource {
+    fn validate(&self) -> Result<(), AstraError> {
+        // VAL-080: rule_id cannot be empty
+        if self.rule_id.trim().is_empty() {
+            return Err(AstraError::ValidationFailed {
+                context: ErrorContext::validation(
+                    "VAL-080",
+                    "Provide a non-empty rule_id for PolicySource",
+                ),
+                field: Some("rule_id".into()),
+                message: "PolicySource.rule_id cannot be empty".into(),
+            });
+        }
+        Ok(())
+    }
+}
+
+// ============================================================================
+// PolicyDecision
+// ============================================================================
+
+/// A recorded policy decision.
+///
+/// Captures the full context of a policy evaluation for audit, compliance,
+/// and policy tuning. Every decision (including allows) should be recorded.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PolicyDecision {
+    /// Unique decision identifier.
+    pub id: DecisionId,
+
+    /// When the decision was made.
+    pub timestamp: Timestamp,
+
+    /// Correlation ID linking to the originating run/task.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<CorrelationId>,
+
+    /// What action was being evaluated (e.g., "file.write", "network.egress").
+    pub action: String,
+
+    /// Agent/component requesting the action.
+    pub requester: String,
+
+    /// The decision result.
+    pub effect: PolicyEffect,
+
+    /// Source of the deciding rule.
+    pub source: PolicySource,
+
+    /// Human-readable reason for the decision.
+    pub reason: String,
+
+    /// Additional context (e.g., matched patterns, values checked).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub context: HashMap<String, Value>,
+
+    /// Duration of policy evaluation in microseconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eval_duration_us: Option<u64>,
+}
+
+impl PolicyDecision {
+    /// Create an Allow decision.
+    ///
+    /// ID and timestamp are auto-generated. Reason defaults to a standard message.
+    pub fn allow(
+        action: impl Into<String>,
+        requester: impl Into<String>,
+        source: PolicySource,
+    ) -> Self {
+        Self {
+            id: DecisionId::new(),
+            timestamp: Timestamp::now(),
+            correlation_id: None,
+            action: action.into(),
+            requester: requester.into(),
+            effect: PolicyEffect::Allow,
+            source,
+            reason: "Policy allows this action".into(),
+            context: HashMap::new(),
+            eval_duration_us: None,
+        }
+    }
+
+    /// Create a Deny decision.
+    ///
+    /// ID and timestamp are auto-generated. Reason is required for denials.
+    pub fn deny(
+        action: impl Into<String>,
+        requester: impl Into<String>,
+        source: PolicySource,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: DecisionId::new(),
+            timestamp: Timestamp::now(),
+            correlation_id: None,
+            action: action.into(),
+            requester: requester.into(),
+            effect: PolicyEffect::Deny,
+            source,
+            reason: reason.into(),
+            context: HashMap::new(),
+            eval_duration_us: None,
+        }
+    }
+
+    /// Create an Escalate decision.
+    ///
+    /// ID and timestamp are auto-generated. Reason explains why escalation is needed.
+    pub fn escalate(
+        action: impl Into<String>,
+        requester: impl Into<String>,
+        source: PolicySource,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: DecisionId::new(),
+            timestamp: Timestamp::now(),
+            correlation_id: None,
+            action: action.into(),
+            requester: requester.into(),
+            effect: PolicyEffect::Escalate,
+            source,
+            reason: reason.into(),
+            context: HashMap::new(),
+            eval_duration_us: None,
+        }
+    }
+
+    /// Set the correlation ID.
+    pub fn with_correlation_id(mut self, correlation_id: CorrelationId) -> Self {
+        self.correlation_id = Some(correlation_id);
+        self
+    }
+
+    /// Override the reason.
+    pub fn with_reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason = reason.into();
+        self
+    }
+
+    /// Add context data.
+    pub fn with_context(mut self, key: impl Into<String>, value: Value) -> Self {
+        self.context.insert(key.into(), value);
+        self
+    }
+
+    /// Set the evaluation duration in microseconds.
+    pub fn with_eval_duration_us(mut self, duration_us: u64) -> Self {
+        self.eval_duration_us = Some(duration_us);
+        self
+    }
+
+    /// Check if this decision denies the action.
+    pub fn is_denied(&self) -> bool {
+        self.effect.is_denied()
+    }
+
+    /// Check if this decision allows the action.
+    pub fn is_allowed(&self) -> bool {
+        self.effect.is_allowed()
+    }
+
+    /// Check if this decision requires escalation.
+    pub fn requires_escalation(&self) -> bool {
+        self.effect.requires_escalation()
+    }
+}
+
+impl fmt::Display for PolicyDecision {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "PolicyDecision({}, {}: {} by {})",
+            self.id, self.effect, self.action, self.requester
+        )
+    }
+}
+
+impl Validate for PolicyDecision {
+    fn validate(&self) -> Result<(), AstraError> {
+        // VAL-081: action cannot be empty
+        if self.action.trim().is_empty() {
+            return Err(AstraError::ValidationFailed {
+                context: ErrorContext::validation(
+                    "VAL-081",
+                    "Provide a non-empty action for PolicyDecision",
+                ),
+                field: Some("action".into()),
+                message: "PolicyDecision.action cannot be empty".into(),
+            });
+        }
+
+        // VAL-082: requester cannot be empty
+        if self.requester.trim().is_empty() {
+            return Err(AstraError::ValidationFailed {
+                context: ErrorContext::validation(
+                    "VAL-082",
+                    "Provide a non-empty requester for PolicyDecision",
+                ),
+                field: Some("requester".into()),
+                message: "PolicyDecision.requester cannot be empty".into(),
+            });
+        }
+
+        // VAL-083: reason cannot be empty for Deny/Escalate
+        if (self.effect == PolicyEffect::Deny || self.effect == PolicyEffect::Escalate)
+            && self.reason.trim().is_empty()
+        {
+            return Err(AstraError::ValidationFailed {
+                context: ErrorContext::validation(
+                    "VAL-083",
+                    "Provide a non-empty reason for Deny/Escalate decisions",
+                ),
+                field: Some("reason".into()),
+                message: format!(
+                    "PolicyDecision.reason cannot be empty for {} effect",
+                    self.effect
+                ),
+            });
+        }
+
+        // Validate nested source
+        self.source.validate()?;
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+
+    // ========================================================================
+    // PolicyEffect tests
+    // ========================================================================
+
+    #[test]
+    fn policy_effect_default_is_deny() {
+        assert_eq!(PolicyEffect::default(), PolicyEffect::Deny);
+    }
+
+    #[test]
+    fn policy_effect_display() {
+        assert_eq!(PolicyEffect::Allow.to_string(), "Allow");
+        assert_eq!(PolicyEffect::Deny.to_string(), "Deny");
+        assert_eq!(PolicyEffect::Escalate.to_string(), "Escalate");
+    }
+
+    #[test]
+    fn policy_effect_is_denied() {
+        assert!(!PolicyEffect::Allow.is_denied());
+        assert!(PolicyEffect::Deny.is_denied());
+        assert!(!PolicyEffect::Escalate.is_denied());
+    }
+
+    #[test]
+    fn policy_effect_is_allowed() {
+        assert!(PolicyEffect::Allow.is_allowed());
+        assert!(!PolicyEffect::Deny.is_allowed());
+        assert!(!PolicyEffect::Escalate.is_allowed());
+    }
+
+    #[test]
+    fn policy_effect_requires_escalation() {
+        assert!(!PolicyEffect::Allow.requires_escalation());
+        assert!(!PolicyEffect::Deny.requires_escalation());
+        assert!(PolicyEffect::Escalate.requires_escalation());
+    }
+
+    #[test]
+    fn policy_effect_serde_roundtrip() {
+        for effect in [
+            PolicyEffect::Allow,
+            PolicyEffect::Deny,
+            PolicyEffect::Escalate,
+        ] {
+            let Ok(json) = serde_json::to_string(&effect) else {
+                panic!("serialization should succeed");
+            };
+            let Ok(decoded) = serde_json::from_str::<PolicyEffect>(&json) else {
+                panic!("deserialization should succeed");
+            };
+            assert_eq!(effect, decoded);
+        }
+    }
+
+    #[test]
+    fn policy_effect_serde_names() {
+        let Ok(allow) = serde_json::to_string(&PolicyEffect::Allow) else {
+            panic!("serialization should succeed");
+        };
+        assert_eq!(allow, "\"allow\"");
+
+        let Ok(deny) = serde_json::to_string(&PolicyEffect::Deny) else {
+            panic!("serialization should succeed");
+        };
+        assert_eq!(deny, "\"deny\"");
+
+        let Ok(escalate) = serde_json::to_string(&PolicyEffect::Escalate) else {
+            panic!("serialization should succeed");
+        };
+        assert_eq!(escalate, "\"escalate\"");
+    }
+
+    // ========================================================================
+    // PolicyLevel tests
+    // ========================================================================
+
+    #[test]
+    fn policy_level_default_is_global() {
+        assert_eq!(PolicyLevel::default(), PolicyLevel::Global);
+    }
+
+    #[test]
+    fn policy_level_display() {
+        assert_eq!(PolicyLevel::Global.to_string(), "Global");
+        assert_eq!(PolicyLevel::Domain.to_string(), "Domain");
+        assert_eq!(PolicyLevel::Capability.to_string(), "Capability");
+        assert_eq!(PolicyLevel::Session.to_string(), "Session");
+    }
+
+    #[test]
+    fn policy_level_ordering() {
+        assert!(PolicyLevel::Global < PolicyLevel::Domain);
+        assert!(PolicyLevel::Domain < PolicyLevel::Capability);
+        assert!(PolicyLevel::Capability < PolicyLevel::Session);
+    }
+
+    #[test]
+    fn policy_level_overrides() {
+        assert!(PolicyLevel::Session.overrides(PolicyLevel::Capability));
+        assert!(PolicyLevel::Session.overrides(PolicyLevel::Domain));
+        assert!(PolicyLevel::Session.overrides(PolicyLevel::Global));
+        assert!(PolicyLevel::Capability.overrides(PolicyLevel::Domain));
+        assert!(PolicyLevel::Capability.overrides(PolicyLevel::Global));
+        assert!(PolicyLevel::Domain.overrides(PolicyLevel::Global));
+
+        assert!(!PolicyLevel::Global.overrides(PolicyLevel::Domain));
+        assert!(!PolicyLevel::Global.overrides(PolicyLevel::Global));
+    }
+
+    #[test]
+    fn policy_level_serde_roundtrip() {
+        for level in [
+            PolicyLevel::Global,
+            PolicyLevel::Domain,
+            PolicyLevel::Capability,
+            PolicyLevel::Session,
+        ] {
+            let Ok(json) = serde_json::to_string(&level) else {
+                panic!("serialization should succeed");
+            };
+            let Ok(decoded) = serde_json::from_str::<PolicyLevel>(&json) else {
+                panic!("deserialization should succeed");
+            };
+            assert_eq!(level, decoded);
+        }
+    }
+
+    #[test]
+    fn policy_level_serde_names() {
+        let Ok(global) = serde_json::to_string(&PolicyLevel::Global) else {
+            panic!("serialization should succeed");
+        };
+        assert_eq!(global, "\"global\"");
+
+        let Ok(session) = serde_json::to_string(&PolicyLevel::Session) else {
+            panic!("serialization should succeed");
+        };
+        assert_eq!(session, "\"session\"");
+    }
+
+    // ========================================================================
+    // PolicySource tests
+    // ========================================================================
+
+    #[test]
+    fn policy_source_new() {
+        let source = PolicySource::new("rule-001", PolicyLevel::Global);
+        assert_eq!(source.rule_id, "rule-001");
+        assert_eq!(source.level, PolicyLevel::Global);
+        assert!(source.path.is_none());
+    }
+
+    #[test]
+    fn policy_source_with_path() {
+        let source = PolicySource::new("rule-002", PolicyLevel::Domain)
+            .with_path("/etc/astra/policies/domain.yaml");
+        assert_eq!(source.rule_id, "rule-002");
+        assert_eq!(source.level, PolicyLevel::Domain);
+        assert_eq!(source.path, Some("/etc/astra/policies/domain.yaml".into()));
+    }
+
+    #[test]
+    fn policy_source_display() {
+        let source = PolicySource::new("sandbox-check", PolicyLevel::Capability);
+        assert_eq!(source.to_string(), "sandbox-check@Capability");
+    }
+
+    #[test]
+    fn policy_source_validate_success() {
+        let source = PolicySource::new("valid-rule", PolicyLevel::Global);
+        assert!(source.validate().is_ok());
+    }
+
+    #[test]
+    fn policy_source_validate_empty_rule_id() {
+        let source = PolicySource::new("", PolicyLevel::Global);
+        let result = source.validate();
+        assert!(result.is_err());
+
+        let Err(AstraError::ValidationFailed { context, .. }) = result else {
+            panic!("expected ValidationFailed");
+        };
+        assert_eq!(context.error_code, "VAL-080");
+    }
+
+    #[test]
+    fn policy_source_validate_whitespace_rule_id() {
+        let source = PolicySource::new("   ", PolicyLevel::Global);
+        let result = source.validate();
+        assert!(result.is_err());
+
+        let Err(AstraError::ValidationFailed { context, .. }) = result else {
+            panic!("expected ValidationFailed");
+        };
+        assert_eq!(context.error_code, "VAL-080");
+    }
+
+    #[test]
+    fn policy_source_serde_roundtrip() {
+        let source =
+            PolicySource::new("rule-001", PolicyLevel::Domain).with_path("/path/to/policy.yaml");
+
+        let Ok(json) = serde_json::to_string(&source) else {
+            panic!("serialization should succeed");
+        };
+        let Ok(decoded) = serde_json::from_str::<PolicySource>(&json) else {
+            panic!("deserialization should succeed");
+        };
+        assert_eq!(source, decoded);
+    }
+
+    #[test]
+    fn policy_source_serde_skips_none_path() {
+        let source = PolicySource::new("rule-001", PolicyLevel::Global);
+        let Ok(json) = serde_json::to_string(&source) else {
+            panic!("serialization should succeed");
+        };
+        assert!(!json.contains("\"path\""));
+    }
+
+    // ========================================================================
+    // PolicyDecision tests
+    // ========================================================================
+
+    #[test]
+    fn policy_decision_allow() {
+        let source = PolicySource::new("rule-001", PolicyLevel::Global);
+        let decision = PolicyDecision::allow("file.read", "agent-123", source);
+
+        assert_eq!(decision.action, "file.read");
+        assert_eq!(decision.requester, "agent-123");
+        assert_eq!(decision.effect, PolicyEffect::Allow);
+        assert!(decision.is_allowed());
+        assert!(!decision.is_denied());
+        assert!(!decision.requires_escalation());
+    }
+
+    #[test]
+    fn policy_decision_deny() {
+        let source = PolicySource::new("rule-002", PolicyLevel::Domain);
+        let decision = PolicyDecision::deny(
+            "network.egress",
+            "agent-456",
+            source,
+            "Egress blocked at sandbox tier 1",
+        );
+
+        assert_eq!(decision.action, "network.egress");
+        assert_eq!(decision.requester, "agent-456");
+        assert_eq!(decision.effect, PolicyEffect::Deny);
+        assert_eq!(decision.reason, "Egress blocked at sandbox tier 1");
+        assert!(decision.is_denied());
+        assert!(!decision.is_allowed());
+    }
+
+    #[test]
+    fn policy_decision_escalate() {
+        let source = PolicySource::new("rule-003", PolicyLevel::Capability);
+        let decision = PolicyDecision::escalate(
+            "admin.delete",
+            "agent-789",
+            source,
+            "Destructive action requires human approval",
+        );
+
+        assert_eq!(decision.action, "admin.delete");
+        assert_eq!(decision.effect, PolicyEffect::Escalate);
+        assert!(decision.requires_escalation());
+        assert!(!decision.is_allowed());
+        assert!(!decision.is_denied());
+    }
+
+    #[test]
+    fn policy_decision_builder_methods() {
+        let source = PolicySource::new("rule-001", PolicyLevel::Global);
+        let correlation = CorrelationId::new();
+
+        let decision = PolicyDecision::allow("test.action", "test-agent", source)
+            .with_correlation_id(correlation)
+            .with_reason("Custom reason")
+            .with_context("key", Value::String("value".into()))
+            .with_eval_duration_us(150);
+
+        assert!(decision.correlation_id.is_some());
+        assert_eq!(decision.reason, "Custom reason");
+        assert_eq!(
+            decision.context.get("key"),
+            Some(&Value::String("value".into()))
+        );
+        assert_eq!(decision.eval_duration_us, Some(150));
+    }
+
+    #[test]
+    fn policy_decision_display() {
+        let source = PolicySource::new("rule-001", PolicyLevel::Global);
+        let decision = PolicyDecision::deny("file.write", "agent-001", source, "Blocked");
+        let display = decision.to_string();
+
+        assert!(display.contains("PolicyDecision"));
+        assert!(display.contains("Deny"));
+        assert!(display.contains("file.write"));
+        assert!(display.contains("agent-001"));
+    }
+
+    #[test]
+    fn policy_decision_validate_success() {
+        let source = PolicySource::new("rule-001", PolicyLevel::Global);
+        let decision = PolicyDecision::allow("valid.action", "valid-agent", source);
+        assert!(decision.validate().is_ok());
+    }
+
+    #[test]
+    fn policy_decision_validate_empty_action() {
+        let source = PolicySource::new("rule-001", PolicyLevel::Global);
+        let mut decision = PolicyDecision::allow("action", "agent", source);
+        decision.action = "".into();
+
+        let result = decision.validate();
+        assert!(result.is_err());
+
+        let Err(AstraError::ValidationFailed { context, .. }) = result else {
+            panic!("expected ValidationFailed");
+        };
+        assert_eq!(context.error_code, "VAL-081");
+    }
+
+    #[test]
+    fn policy_decision_validate_whitespace_action() {
+        let source = PolicySource::new("rule-001", PolicyLevel::Global);
+        let mut decision = PolicyDecision::allow("action", "agent", source);
+        decision.action = "   ".into();
+
+        let result = decision.validate();
+        assert!(result.is_err());
+
+        let Err(AstraError::ValidationFailed { context, .. }) = result else {
+            panic!("expected ValidationFailed");
+        };
+        assert_eq!(context.error_code, "VAL-081");
+    }
+
+    #[test]
+    fn policy_decision_validate_empty_requester() {
+        let source = PolicySource::new("rule-001", PolicyLevel::Global);
+        let mut decision = PolicyDecision::allow("action", "agent", source);
+        decision.requester = "".into();
+
+        let result = decision.validate();
+        assert!(result.is_err());
+
+        let Err(AstraError::ValidationFailed { context, .. }) = result else {
+            panic!("expected ValidationFailed");
+        };
+        assert_eq!(context.error_code, "VAL-082");
+    }
+
+    #[test]
+    fn policy_decision_validate_empty_reason_deny() {
+        let source = PolicySource::new("rule-001", PolicyLevel::Global);
+        let mut decision = PolicyDecision::deny("action", "agent", source, "reason");
+        decision.reason = "".into();
+
+        let result = decision.validate();
+        assert!(result.is_err());
+
+        let Err(AstraError::ValidationFailed { context, .. }) = result else {
+            panic!("expected ValidationFailed");
+        };
+        assert_eq!(context.error_code, "VAL-083");
+    }
+
+    #[test]
+    fn policy_decision_validate_empty_reason_escalate() {
+        let source = PolicySource::new("rule-001", PolicyLevel::Global);
+        let mut decision = PolicyDecision::escalate("action", "agent", source, "reason");
+        decision.reason = "   ".into();
+
+        let result = decision.validate();
+        assert!(result.is_err());
+
+        let Err(AstraError::ValidationFailed { context, .. }) = result else {
+            panic!("expected ValidationFailed");
+        };
+        assert_eq!(context.error_code, "VAL-083");
+    }
+
+    #[test]
+    fn policy_decision_validate_empty_reason_allow_ok() {
+        // Allow decisions can have empty reasons
+        let source = PolicySource::new("rule-001", PolicyLevel::Global);
+        let mut decision = PolicyDecision::allow("action", "agent", source);
+        decision.reason = "".into();
+
+        assert!(decision.validate().is_ok());
+    }
+
+    #[test]
+    fn policy_decision_validate_invalid_source() {
+        let source = PolicySource::new("", PolicyLevel::Global); // Invalid
+        let decision = PolicyDecision::allow("action", "agent", source);
+
+        let result = decision.validate();
+        assert!(result.is_err());
+
+        let Err(AstraError::ValidationFailed { context, .. }) = result else {
+            panic!("expected ValidationFailed");
+        };
+        assert_eq!(context.error_code, "VAL-080");
+    }
+
+    #[test]
+    fn policy_decision_serde_roundtrip() {
+        let source =
+            PolicySource::new("rule-001", PolicyLevel::Domain).with_path("/path/to/policy.yaml");
+        let correlation = CorrelationId::new();
+
+        let decision =
+            PolicyDecision::deny("file.delete", "agent-cleanup", source, "Not permitted")
+                .with_correlation_id(correlation)
+                .with_context("target", Value::String("/tmp/sensitive".into()))
+                .with_eval_duration_us(42);
+
+        let Ok(json) = serde_json::to_string(&decision) else {
+            panic!("serialization should succeed");
+        };
+        let Ok(decoded) = serde_json::from_str::<PolicyDecision>(&json) else {
+            panic!("deserialization should succeed");
+        };
+
+        assert_eq!(decision.id, decoded.id);
+        assert_eq!(decision.action, decoded.action);
+        assert_eq!(decision.requester, decoded.requester);
+        assert_eq!(decision.effect, decoded.effect);
+        assert_eq!(decision.reason, decoded.reason);
+        assert_eq!(decision.source, decoded.source);
+        assert_eq!(decision.eval_duration_us, decoded.eval_duration_us);
+    }
+
+    #[test]
+    fn policy_decision_serde_skips_empty_context() {
+        let source = PolicySource::new("rule-001", PolicyLevel::Global);
+        let decision = PolicyDecision::allow("action", "agent", source);
+
+        let Ok(json) = serde_json::to_string(&decision) else {
+            panic!("serialization should succeed");
+        };
+        assert!(!json.contains("\"context\""));
+    }
+
+    #[test]
+    fn policy_decision_serde_skips_none_fields() {
+        let source = PolicySource::new("rule-001", PolicyLevel::Global);
+        let decision = PolicyDecision::allow("action", "agent", source);
+
+        let Ok(json) = serde_json::to_string(&decision) else {
+            panic!("serialization should succeed");
+        };
+        assert!(!json.contains("\"correlation_id\""));
+        assert!(!json.contains("\"eval_duration_us\""));
+    }
+
+    #[test]
+    fn policy_decision_id_auto_generated() {
+        let source = PolicySource::new("rule-001", PolicyLevel::Global);
+        let d1 = PolicyDecision::allow("action", "agent", source.clone());
+        let d2 = PolicyDecision::allow("action", "agent", source);
+
+        assert_ne!(d1.id, d2.id);
+    }
+
+    #[test]
+    fn policy_decision_timestamp_auto_generated() {
+        let source = PolicySource::new("rule-001", PolicyLevel::Global);
+        let decision = PolicyDecision::allow("action", "agent", source);
+
+        // Timestamp should be recent (within last second)
+        assert!(!decision.timestamp.is_future());
+    }
+}

--- a/crates/astra-types/src/prelude.rs
+++ b/crates/astra-types/src/prelude.rs
@@ -29,7 +29,8 @@ pub use crate::task::{Budget, Constraints, TaskEnvelope, TaskEnvelopeBuilder};
 
 // ID types
 pub use crate::id::{
-    ArtifactId, CapabilityId, ContextId, CorrelationId, PolicyId, ProfileId, TaskId, WorkspaceId,
+    ArtifactId, CapabilityId, ContextId, CorrelationId, DecisionId, PolicyId, ProfileId, TaskId,
+    WorkspaceId,
 };
 
 // Capability types
@@ -62,3 +63,9 @@ pub use crate::artifact::{Artifact, ArtifactLinks, ArtifactState};
 
 // Context types
 pub use crate::context::{ContextItem, ContextKind, ContextScope};
+
+// Policy types
+pub use crate::policy::{PolicyDecision, PolicyEffect, PolicyLevel, PolicySource};
+
+// Report types
+pub use crate::report::{BudgetSnapshot, Intervention, RunReport, TimelineEvent};

--- a/crates/astra-types/src/report.rs
+++ b/crates/astra-types/src/report.rs
@@ -1,0 +1,1192 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! RunReport — complete execution trace of a workflow run.
+//!
+//! Captures the full timeline, budget consumption, policy decisions, and operator
+//! interventions for debugging, replay, and compliance.
+//!
+//! # Design
+//!
+//! - Timeline events are a discriminated union enabling filtering and analysis
+//! - Interventions (pause, kill, budget grant) are first-class citizens
+//! - Budget snapshots track allocation vs consumption
+//! - Immutable once created; reports are append-only during run, then finalized
+//!
+//! # Example
+//!
+//! ```
+//! use astra_types::{RunReport, TimelineEvent, OutcomeStatus, TaskId, Timestamp};
+//!
+//! let mut report = RunReport::new("run-001", Timestamp::now());
+//!
+//! report.add_event(TimelineEvent::RunStarted {
+//!     timestamp: Timestamp::now(),
+//!     task_id: TaskId::new(),
+//! });
+//!
+//! report.complete(OutcomeStatus::Success, Timestamp::now());
+//! assert_eq!(report.status, OutcomeStatus::Success);
+//! ```
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AstraError, ErrorContext};
+use crate::id::{ArtifactId, CapabilityId, DecisionId, TaskId};
+use crate::outcome::OutcomeStatus;
+use crate::policy::PolicyEffect;
+use crate::task::Budget;
+use crate::time::Timestamp;
+use crate::validate::Validate;
+
+// ============================================================================
+// TimelineEvent
+// ============================================================================
+
+/// Events in the run timeline.
+///
+/// Each variant captures a discrete occurrence during run execution. Use the
+/// `timestamp()` method to get the event time without pattern matching.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TimelineEvent {
+    /// Run started.
+    RunStarted {
+        /// When the run started.
+        timestamp: Timestamp,
+        /// The root task for this run.
+        task_id: TaskId,
+    },
+
+    /// Agent spawned.
+    AgentSpawned {
+        /// When the agent was spawned.
+        timestamp: Timestamp,
+        /// Agent identifier. Design: String until AgentId is defined.
+        agent_id: String,
+        /// Profile used to spawn the agent. Design: String until ProfileId is typed.
+        profile_id: String,
+    },
+
+    /// Task dispatched to agent.
+    TaskDispatched {
+        /// When the task was dispatched.
+        timestamp: Timestamp,
+        /// The dispatched task.
+        task_id: TaskId,
+        /// Target agent. Design: String until AgentId is defined.
+        agent_id: String,
+    },
+
+    /// Capability invoked.
+    CapabilityInvoked {
+        /// When the capability was invoked.
+        timestamp: Timestamp,
+        /// Which capability was invoked.
+        capability_id: CapabilityId,
+        /// Agent that invoked the capability. Design: String until AgentId is defined.
+        agent_id: String,
+        /// How long the invocation took in milliseconds.
+        duration_ms: u64,
+    },
+
+    /// Model called.
+    ModelCalled {
+        /// When the model was called.
+        timestamp: Timestamp,
+        /// Model identifier (e.g., "gpt-4", "claude-3").
+        model_id: String,
+        /// Tokens consumed (input + output).
+        tokens_used: u64,
+        /// How long the call took in milliseconds.
+        duration_ms: u64,
+    },
+
+    /// Policy decision made.
+    PolicyEvaluated {
+        /// When the policy was evaluated.
+        timestamp: Timestamp,
+        /// Reference to the full PolicyDecision.
+        decision_id: DecisionId,
+        /// The decision result.
+        effect: PolicyEffect,
+    },
+
+    /// Artifact created or modified.
+    ArtifactMutated {
+        /// When the mutation occurred.
+        timestamp: Timestamp,
+        /// The affected artifact.
+        artifact_id: ArtifactId,
+        /// Type of mutation (e.g., "created", "updated", "state_changed").
+        mutation: String,
+    },
+
+    /// Agent completed.
+    AgentCompleted {
+        /// When the agent completed.
+        timestamp: Timestamp,
+        /// Which agent completed. Design: String until AgentId is defined.
+        agent_id: String,
+        /// How the agent completed.
+        status: OutcomeStatus,
+    },
+
+    /// Run completed.
+    RunCompleted {
+        /// When the run completed.
+        timestamp: Timestamp,
+        /// Final run status.
+        status: OutcomeStatus,
+    },
+
+    /// Error occurred.
+    ErrorOccurred {
+        /// When the error occurred.
+        timestamp: Timestamp,
+        /// Error code for categorization.
+        error_code: String,
+        /// Human-readable error message.
+        message: String,
+    },
+}
+
+impl TimelineEvent {
+    /// Get the timestamp of this event.
+    pub fn timestamp(&self) -> &Timestamp {
+        match self {
+            Self::RunStarted { timestamp, .. } => timestamp,
+            Self::AgentSpawned { timestamp, .. } => timestamp,
+            Self::TaskDispatched { timestamp, .. } => timestamp,
+            Self::CapabilityInvoked { timestamp, .. } => timestamp,
+            Self::ModelCalled { timestamp, .. } => timestamp,
+            Self::PolicyEvaluated { timestamp, .. } => timestamp,
+            Self::ArtifactMutated { timestamp, .. } => timestamp,
+            Self::AgentCompleted { timestamp, .. } => timestamp,
+            Self::RunCompleted { timestamp, .. } => timestamp,
+            Self::ErrorOccurred { timestamp, .. } => timestamp,
+        }
+    }
+
+    /// Get the event type name.
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            Self::RunStarted { .. } => "run_started",
+            Self::AgentSpawned { .. } => "agent_spawned",
+            Self::TaskDispatched { .. } => "task_dispatched",
+            Self::CapabilityInvoked { .. } => "capability_invoked",
+            Self::ModelCalled { .. } => "model_called",
+            Self::PolicyEvaluated { .. } => "policy_evaluated",
+            Self::ArtifactMutated { .. } => "artifact_mutated",
+            Self::AgentCompleted { .. } => "agent_completed",
+            Self::RunCompleted { .. } => "run_completed",
+            Self::ErrorOccurred { .. } => "error_occurred",
+        }
+    }
+}
+
+impl fmt::Display for TimelineEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}@{}", self.event_type(), self.timestamp())
+    }
+}
+
+// ============================================================================
+// Intervention
+// ============================================================================
+
+/// Operator intervention during a run.
+///
+/// Captures human or system actions that affect run execution.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Intervention {
+    /// Paused execution.
+    Pause {
+        /// When the pause was issued.
+        timestamp: Timestamp,
+        /// Why execution was paused.
+        reason: String,
+    },
+
+    /// Resumed execution.
+    Resume {
+        /// When execution was resumed.
+        timestamp: Timestamp,
+    },
+
+    /// Killed run or agent.
+    Kill {
+        /// When the kill was issued.
+        timestamp: Timestamp,
+        /// What was killed (run_id or agent_id).
+        target: String,
+        /// Why execution was killed.
+        reason: String,
+    },
+
+    /// Granted additional budget.
+    BudgetGrant {
+        /// When the grant was issued.
+        timestamp: Timestamp,
+        /// Budget type (e.g., "tokens", "time_ms", "cost_usd").
+        budget_type: String,
+        /// Amount granted.
+        amount: u64,
+    },
+
+    /// Overrode a policy decision.
+    PolicyOverride {
+        /// When the override was issued.
+        timestamp: Timestamp,
+        /// Which decision was overridden.
+        decision_id: DecisionId,
+        /// The new effect to apply.
+        new_effect: PolicyEffect,
+    },
+}
+
+impl Intervention {
+    /// Get the timestamp of this intervention.
+    pub fn timestamp(&self) -> &Timestamp {
+        match self {
+            Self::Pause { timestamp, .. } => timestamp,
+            Self::Resume { timestamp } => timestamp,
+            Self::Kill { timestamp, .. } => timestamp,
+            Self::BudgetGrant { timestamp, .. } => timestamp,
+            Self::PolicyOverride { timestamp, .. } => timestamp,
+        }
+    }
+
+    /// Get the intervention type name.
+    pub fn intervention_type(&self) -> &'static str {
+        match self {
+            Self::Pause { .. } => "pause",
+            Self::Resume { .. } => "resume",
+            Self::Kill { .. } => "kill",
+            Self::BudgetGrant { .. } => "budget_grant",
+            Self::PolicyOverride { .. } => "policy_override",
+        }
+    }
+}
+
+impl fmt::Display for Intervention {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}@{}", self.intervention_type(), self.timestamp())
+    }
+}
+
+// ============================================================================
+// BudgetSnapshot
+// ============================================================================
+
+/// Budget consumption snapshot at a point in time.
+///
+/// Tracks allocated, consumed, and remaining budget across all resource types.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BudgetSnapshot {
+    /// Allocated budget limits.
+    pub allocated: Budget,
+    /// Budget consumed so far.
+    pub consumed: Budget,
+    /// Remaining budget.
+    pub remaining: Budget,
+}
+
+impl BudgetSnapshot {
+    /// Create a new budget snapshot from allocated budget.
+    ///
+    /// Consumed is zeroed, remaining equals allocated.
+    pub fn new(allocated: Budget) -> Self {
+        Self {
+            allocated: allocated.clone(),
+            consumed: Budget {
+                tokens: 0,
+                time_ms: 0,
+                cost_usd: 0.0,
+                max_actions: 0,
+            },
+            remaining: allocated,
+        }
+    }
+
+    /// Create an empty snapshot with zero budgets.
+    pub fn empty() -> Self {
+        let zero = Budget {
+            tokens: 0,
+            time_ms: 0,
+            cost_usd: 0.0,
+            max_actions: 0,
+        };
+        Self {
+            allocated: zero.clone(),
+            consumed: zero.clone(),
+            remaining: zero,
+        }
+    }
+}
+
+impl Default for BudgetSnapshot {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl fmt::Display for BudgetSnapshot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Budget(tokens: {}/{}, time: {}ms/{}ms, cost: ${:.2}/${:.2})",
+            self.consumed.tokens,
+            self.allocated.tokens,
+            self.consumed.time_ms,
+            self.allocated.time_ms,
+            self.consumed.cost_usd,
+            self.allocated.cost_usd
+        )
+    }
+}
+
+// ============================================================================
+// RunReport
+// ============================================================================
+
+/// Complete execution trace of a workflow run.
+///
+/// Captures timeline, budget consumption, policy decisions, and interventions
+/// for debugging, replay, and compliance.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RunReport {
+    /// Unique run identifier.
+    ///
+    /// Design: String until RunId is defined (matches ArtifactLinks.run_id).
+    pub run_id: String,
+
+    /// Overall run status.
+    pub status: OutcomeStatus,
+
+    /// Start timestamp.
+    pub started_at: Timestamp,
+
+    /// End timestamp (set when completed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<Timestamp>,
+
+    /// Chronological event timeline.
+    #[serde(default)]
+    pub timeline: Vec<TimelineEvent>,
+
+    /// Artifact IDs produced/modified.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<ArtifactId>,
+
+    /// Budget snapshot at end of run.
+    #[serde(default)]
+    pub budgets: BudgetSnapshot,
+
+    /// Policy decision IDs made during run.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub policy_decisions: Vec<DecisionId>,
+
+    /// Operator interventions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub interventions: Vec<Intervention>,
+
+    /// Error summary if failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+
+    /// Agent IDs involved in this run.
+    ///
+    /// Design: Vec<String> until AgentId is defined.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agents: Vec<String>,
+}
+
+impl RunReport {
+    /// Create a new run report.
+    ///
+    /// Status starts as `Partial` (in progress).
+    pub fn new(run_id: impl Into<String>, started_at: Timestamp) -> Self {
+        Self {
+            run_id: run_id.into(),
+            status: OutcomeStatus::Partial,
+            started_at,
+            completed_at: None,
+            timeline: Vec::new(),
+            artifacts: Vec::new(),
+            budgets: BudgetSnapshot::default(),
+            policy_decisions: Vec::new(),
+            interventions: Vec::new(),
+            error: None,
+            agents: Vec::new(),
+        }
+    }
+
+    /// Add an event to the timeline.
+    pub fn add_event(&mut self, event: TimelineEvent) {
+        self.timeline.push(event);
+    }
+
+    /// Add an artifact to the report.
+    pub fn add_artifact(&mut self, artifact_id: ArtifactId) {
+        self.artifacts.push(artifact_id);
+    }
+
+    /// Add a policy decision to the report.
+    pub fn add_policy_decision(&mut self, decision_id: DecisionId) {
+        self.policy_decisions.push(decision_id);
+    }
+
+    /// Add an intervention to the report.
+    pub fn add_intervention(&mut self, intervention: Intervention) {
+        self.interventions.push(intervention);
+    }
+
+    /// Add an agent to the report.
+    pub fn add_agent(&mut self, agent_id: impl Into<String>) {
+        self.agents.push(agent_id.into());
+    }
+
+    /// Set the budget snapshot.
+    pub fn set_budgets(&mut self, budgets: BudgetSnapshot) {
+        self.budgets = budgets;
+    }
+
+    /// Set the error message.
+    pub fn set_error(&mut self, error: impl Into<String>) {
+        self.error = Some(error.into());
+    }
+
+    /// Mark run as completed.
+    pub fn complete(&mut self, status: OutcomeStatus, completed_at: Timestamp) {
+        self.status = status;
+        self.completed_at = Some(completed_at);
+    }
+
+    /// Get duration in milliseconds if completed.
+    ///
+    /// Returns `None` if the run is not yet completed or if timestamps are invalid.
+    pub fn duration_ms(&self) -> Option<u64> {
+        let completed = self.completed_at.as_ref()?;
+        let start_ms = self.started_at.as_millis();
+        let end_ms = completed.as_millis();
+
+        if end_ms >= start_ms {
+            Some((end_ms - start_ms) as u64)
+        } else {
+            // Clock skew - started_at is after completed_at
+            None
+        }
+    }
+
+    /// Check if the run is still in progress.
+    pub fn is_in_progress(&self) -> bool {
+        self.completed_at.is_none()
+    }
+
+    /// Check if the run completed successfully.
+    pub fn is_success(&self) -> bool {
+        self.status == OutcomeStatus::Success
+    }
+
+    /// Check if the run failed.
+    pub fn is_failure(&self) -> bool {
+        matches!(self.status, OutcomeStatus::Failed | OutcomeStatus::Aborted)
+    }
+}
+
+impl fmt::Display for RunReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(duration) = self.duration_ms() {
+            write!(
+                f,
+                "RunReport({}, status={}, duration={}ms, events={})",
+                self.run_id,
+                self.status,
+                duration,
+                self.timeline.len()
+            )
+        } else {
+            write!(
+                f,
+                "RunReport({}, status={}, events={})",
+                self.run_id,
+                self.status,
+                self.timeline.len()
+            )
+        }
+    }
+}
+
+impl Validate for RunReport {
+    fn validate(&self) -> Result<(), AstraError> {
+        // VAL-084: run_id cannot be empty
+        if self.run_id.trim().is_empty() {
+            return Err(AstraError::ValidationFailed {
+                context: ErrorContext::validation(
+                    "VAL-084",
+                    "Provide a non-empty run_id for RunReport",
+                ),
+                field: Some("run_id".into()),
+                message: "RunReport.run_id cannot be empty".into(),
+            });
+        }
+
+        // VAL-085: started_at must not be after completed_at
+        if let Some(completed) = &self.completed_at {
+            if self.started_at.as_millis() > completed.as_millis() {
+                return Err(AstraError::ValidationFailed {
+                    context: ErrorContext::validation(
+                        "VAL-085",
+                        "started_at must not be after completed_at",
+                    ),
+                    field: Some("started_at".into()),
+                    message: format!(
+                        "RunReport.started_at ({}) is after completed_at ({})",
+                        self.started_at, completed
+                    ),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, Utc};
+
+    // ========================================================================
+    // TimelineEvent tests
+    // ========================================================================
+
+    #[test]
+    fn timeline_event_run_started() {
+        let task_id = TaskId::new();
+        let event = TimelineEvent::RunStarted {
+            timestamp: Timestamp::now(),
+            task_id,
+        };
+
+        assert_eq!(event.event_type(), "run_started");
+        assert!(!event.timestamp().is_future());
+    }
+
+    #[test]
+    fn timeline_event_agent_spawned() {
+        let event = TimelineEvent::AgentSpawned {
+            timestamp: Timestamp::now(),
+            agent_id: "agent-001".into(),
+            profile_id: "profile-001".into(),
+        };
+
+        assert_eq!(event.event_type(), "agent_spawned");
+    }
+
+    #[test]
+    fn timeline_event_capability_invoked() {
+        let Ok(cap_id) = CapabilityId::new("repo.read") else {
+            panic!("valid capability id should parse");
+        };
+        let event = TimelineEvent::CapabilityInvoked {
+            timestamp: Timestamp::now(),
+            capability_id: cap_id,
+            agent_id: "agent-001".into(),
+            duration_ms: 42,
+        };
+
+        assert_eq!(event.event_type(), "capability_invoked");
+    }
+
+    #[test]
+    fn timeline_event_policy_evaluated() {
+        let event = TimelineEvent::PolicyEvaluated {
+            timestamp: Timestamp::now(),
+            decision_id: DecisionId::new(),
+            effect: PolicyEffect::Allow,
+        };
+
+        assert_eq!(event.event_type(), "policy_evaluated");
+    }
+
+    #[test]
+    fn timeline_event_timestamp_accessor() {
+        let ts = Timestamp::now();
+        let event = TimelineEvent::ErrorOccurred {
+            timestamp: ts.clone(),
+            error_code: "ERR-001".into(),
+            message: "Something went wrong".into(),
+        };
+
+        assert_eq!(event.timestamp(), &ts);
+    }
+
+    #[test]
+    fn timeline_event_display() {
+        let event = TimelineEvent::RunCompleted {
+            timestamp: Timestamp::now(),
+            status: OutcomeStatus::Success,
+        };
+        let display = event.to_string();
+
+        assert!(display.contains("run_completed"));
+        assert!(display.contains("@"));
+    }
+
+    #[test]
+    fn timeline_event_serde_roundtrip() {
+        let events = vec![
+            TimelineEvent::RunStarted {
+                timestamp: Timestamp::now(),
+                task_id: TaskId::new(),
+            },
+            TimelineEvent::ModelCalled {
+                timestamp: Timestamp::now(),
+                model_id: "gpt-4".into(),
+                tokens_used: 1500,
+                duration_ms: 2300,
+            },
+            TimelineEvent::RunCompleted {
+                timestamp: Timestamp::now(),
+                status: OutcomeStatus::Success,
+            },
+        ];
+
+        for event in events {
+            let Ok(json) = serde_json::to_string(&event) else {
+                panic!("serialization should succeed");
+            };
+            let Ok(decoded) = serde_json::from_str::<TimelineEvent>(&json) else {
+                panic!("deserialization should succeed");
+            };
+            assert_eq!(event.event_type(), decoded.event_type());
+        }
+    }
+
+    #[test]
+    fn timeline_event_serde_tagged() {
+        let event = TimelineEvent::RunStarted {
+            timestamp: Timestamp::now(),
+            task_id: TaskId::new(),
+        };
+
+        let Ok(json) = serde_json::to_string(&event) else {
+            panic!("serialization should succeed");
+        };
+
+        assert!(json.contains("\"type\":\"run_started\""));
+    }
+
+    // ========================================================================
+    // Intervention tests
+    // ========================================================================
+
+    #[test]
+    fn intervention_pause() {
+        let intervention = Intervention::Pause {
+            timestamp: Timestamp::now(),
+            reason: "User requested pause".into(),
+        };
+
+        assert_eq!(intervention.intervention_type(), "pause");
+    }
+
+    #[test]
+    fn intervention_resume() {
+        let intervention = Intervention::Resume {
+            timestamp: Timestamp::now(),
+        };
+
+        assert_eq!(intervention.intervention_type(), "resume");
+    }
+
+    #[test]
+    fn intervention_kill() {
+        let intervention = Intervention::Kill {
+            timestamp: Timestamp::now(),
+            target: "agent-001".into(),
+            reason: "Unresponsive".into(),
+        };
+
+        assert_eq!(intervention.intervention_type(), "kill");
+    }
+
+    #[test]
+    fn intervention_budget_grant() {
+        let intervention = Intervention::BudgetGrant {
+            timestamp: Timestamp::now(),
+            budget_type: "tokens".into(),
+            amount: 50000,
+        };
+
+        assert_eq!(intervention.intervention_type(), "budget_grant");
+    }
+
+    #[test]
+    fn intervention_policy_override() {
+        let intervention = Intervention::PolicyOverride {
+            timestamp: Timestamp::now(),
+            decision_id: DecisionId::new(),
+            new_effect: PolicyEffect::Allow,
+        };
+
+        assert_eq!(intervention.intervention_type(), "policy_override");
+    }
+
+    #[test]
+    fn intervention_timestamp_accessor() {
+        let ts = Timestamp::now();
+        let intervention = Intervention::Resume {
+            timestamp: ts.clone(),
+        };
+
+        assert_eq!(intervention.timestamp(), &ts);
+    }
+
+    #[test]
+    fn intervention_display() {
+        let intervention = Intervention::Pause {
+            timestamp: Timestamp::now(),
+            reason: "Test".into(),
+        };
+        let display = intervention.to_string();
+
+        assert!(display.contains("pause"));
+        assert!(display.contains("@"));
+    }
+
+    #[test]
+    fn intervention_serde_roundtrip() {
+        let interventions = vec![
+            Intervention::Pause {
+                timestamp: Timestamp::now(),
+                reason: "Test pause".into(),
+            },
+            Intervention::Resume {
+                timestamp: Timestamp::now(),
+            },
+            Intervention::Kill {
+                timestamp: Timestamp::now(),
+                target: "run-001".into(),
+                reason: "Timeout".into(),
+            },
+        ];
+
+        for intervention in interventions {
+            let Ok(json) = serde_json::to_string(&intervention) else {
+                panic!("serialization should succeed");
+            };
+            let Ok(decoded) = serde_json::from_str::<Intervention>(&json) else {
+                panic!("deserialization should succeed");
+            };
+            assert_eq!(
+                intervention.intervention_type(),
+                decoded.intervention_type()
+            );
+        }
+    }
+
+    #[test]
+    fn intervention_serde_tagged() {
+        let intervention = Intervention::BudgetGrant {
+            timestamp: Timestamp::now(),
+            budget_type: "tokens".into(),
+            amount: 1000,
+        };
+
+        let Ok(json) = serde_json::to_string(&intervention) else {
+            panic!("serialization should succeed");
+        };
+
+        assert!(json.contains("\"type\":\"budget_grant\""));
+    }
+
+    // ========================================================================
+    // BudgetSnapshot tests
+    // ========================================================================
+
+    #[test]
+    fn budget_snapshot_new() {
+        let allocated = Budget {
+            tokens: 100_000,
+            time_ms: 300_000,
+            cost_usd: 1.0,
+            max_actions: 100,
+        };
+
+        let snapshot = BudgetSnapshot::new(allocated.clone());
+
+        assert_eq!(snapshot.allocated, allocated);
+        assert_eq!(snapshot.consumed.tokens, 0);
+        assert_eq!(snapshot.consumed.time_ms, 0);
+        assert_eq!(snapshot.consumed.cost_usd, 0.0);
+        assert_eq!(snapshot.consumed.max_actions, 0);
+        assert_eq!(snapshot.remaining, allocated);
+    }
+
+    #[test]
+    fn budget_snapshot_empty() {
+        let snapshot = BudgetSnapshot::empty();
+
+        assert_eq!(snapshot.allocated.tokens, 0);
+        assert_eq!(snapshot.consumed.tokens, 0);
+        assert_eq!(snapshot.remaining.tokens, 0);
+    }
+
+    #[test]
+    fn budget_snapshot_default_is_empty() {
+        let snapshot = BudgetSnapshot::default();
+
+        assert_eq!(snapshot.allocated.tokens, 0);
+        assert_eq!(snapshot.consumed.tokens, 0);
+        assert_eq!(snapshot.remaining.tokens, 0);
+    }
+
+    #[test]
+    fn budget_snapshot_display() {
+        let mut snapshot = BudgetSnapshot::new(Budget {
+            tokens: 100_000,
+            time_ms: 300_000,
+            cost_usd: 1.0,
+            max_actions: 100,
+        });
+        snapshot.consumed = Budget {
+            tokens: 50_000,
+            time_ms: 150_000,
+            cost_usd: 0.5,
+            max_actions: 50,
+        };
+
+        let display = snapshot.to_string();
+        assert!(display.contains("50000/100000"));
+        assert!(display.contains("150000ms/300000ms"));
+    }
+
+    #[test]
+    fn budget_snapshot_serde_roundtrip() {
+        let snapshot = BudgetSnapshot::new(Budget::default());
+
+        let Ok(json) = serde_json::to_string(&snapshot) else {
+            panic!("serialization should succeed");
+        };
+        let Ok(decoded) = serde_json::from_str::<BudgetSnapshot>(&json) else {
+            panic!("deserialization should succeed");
+        };
+
+        assert_eq!(snapshot, decoded);
+    }
+
+    // ========================================================================
+    // RunReport tests
+    // ========================================================================
+
+    #[test]
+    fn run_report_new() {
+        let report = RunReport::new("run-001", Timestamp::now());
+
+        assert_eq!(report.run_id, "run-001");
+        assert_eq!(report.status, OutcomeStatus::Partial);
+        assert!(report.completed_at.is_none());
+        assert!(report.timeline.is_empty());
+        assert!(report.is_in_progress());
+    }
+
+    #[test]
+    fn run_report_add_event() {
+        let mut report = RunReport::new("run-001", Timestamp::now());
+
+        report.add_event(TimelineEvent::RunStarted {
+            timestamp: Timestamp::now(),
+            task_id: TaskId::new(),
+        });
+
+        assert_eq!(report.timeline.len(), 1);
+    }
+
+    #[test]
+    fn run_report_add_artifact() {
+        let mut report = RunReport::new("run-001", Timestamp::now());
+        let artifact_id = ArtifactId::new();
+
+        report.add_artifact(artifact_id);
+
+        assert_eq!(report.artifacts.len(), 1);
+    }
+
+    #[test]
+    fn run_report_add_policy_decision() {
+        let mut report = RunReport::new("run-001", Timestamp::now());
+        let decision_id = DecisionId::new();
+
+        report.add_policy_decision(decision_id);
+
+        assert_eq!(report.policy_decisions.len(), 1);
+    }
+
+    #[test]
+    fn run_report_add_intervention() {
+        let mut report = RunReport::new("run-001", Timestamp::now());
+
+        report.add_intervention(Intervention::Pause {
+            timestamp: Timestamp::now(),
+            reason: "Test".into(),
+        });
+
+        assert_eq!(report.interventions.len(), 1);
+    }
+
+    #[test]
+    fn run_report_add_agent() {
+        let mut report = RunReport::new("run-001", Timestamp::now());
+
+        report.add_agent("agent-001");
+        report.add_agent("agent-002");
+
+        assert_eq!(report.agents.len(), 2);
+    }
+
+    #[test]
+    fn run_report_set_budgets() {
+        let mut report = RunReport::new("run-001", Timestamp::now());
+        let budgets = BudgetSnapshot::new(Budget::default());
+
+        report.set_budgets(budgets.clone());
+
+        assert_eq!(report.budgets, budgets);
+    }
+
+    #[test]
+    fn run_report_set_error() {
+        let mut report = RunReport::new("run-001", Timestamp::now());
+
+        report.set_error("Something went wrong");
+
+        assert_eq!(report.error, Some("Something went wrong".into()));
+    }
+
+    #[test]
+    fn run_report_complete() {
+        let mut report = RunReport::new("run-001", Timestamp::now());
+
+        report.complete(OutcomeStatus::Success, Timestamp::now());
+
+        assert_eq!(report.status, OutcomeStatus::Success);
+        assert!(report.completed_at.is_some());
+        assert!(!report.is_in_progress());
+        assert!(report.is_success());
+    }
+
+    #[test]
+    fn run_report_duration_ms() {
+        let start = Timestamp::from(Utc::now() - Duration::milliseconds(1000));
+        let end = Timestamp::now();
+
+        let mut report = RunReport::new("run-001", start);
+        report.complete(OutcomeStatus::Success, end);
+
+        let duration = report.duration_ms();
+        assert!(duration.is_some());
+
+        // Should be approximately 1000ms (allow some tolerance)
+        let Some(ms) = duration else {
+            panic!("duration should be Some");
+        };
+        assert!((900..=1100).contains(&ms));
+    }
+
+    #[test]
+    fn run_report_duration_ms_none_when_not_completed() {
+        let report = RunReport::new("run-001", Timestamp::now());
+        assert!(report.duration_ms().is_none());
+    }
+
+    #[test]
+    fn run_report_duration_ms_zero_for_instant() {
+        let ts = Timestamp::now();
+        let mut report = RunReport::new("run-001", ts.clone());
+        report.complete(OutcomeStatus::Success, ts);
+
+        let duration = report.duration_ms();
+        assert_eq!(duration, Some(0));
+    }
+
+    #[test]
+    fn run_report_is_success() {
+        let mut report = RunReport::new("run-001", Timestamp::now());
+
+        assert!(!report.is_success());
+
+        report.complete(OutcomeStatus::Success, Timestamp::now());
+        assert!(report.is_success());
+    }
+
+    #[test]
+    fn run_report_is_failure() {
+        let mut report = RunReport::new("run-001", Timestamp::now());
+
+        assert!(!report.is_failure());
+
+        report.complete(OutcomeStatus::Failed, Timestamp::now());
+        assert!(report.is_failure());
+
+        let mut report2 = RunReport::new("run-002", Timestamp::now());
+        report2.complete(OutcomeStatus::Aborted, Timestamp::now());
+        assert!(report2.is_failure());
+    }
+
+    #[test]
+    fn run_report_display_in_progress() {
+        let report = RunReport::new("run-001", Timestamp::now());
+        let display = report.to_string();
+
+        assert!(display.contains("run-001"));
+        assert!(display.contains("partial"));
+        assert!(!display.contains("duration"));
+    }
+
+    #[test]
+    fn run_report_display_completed() {
+        let start = Timestamp::from(Utc::now() - Duration::milliseconds(1000));
+        let mut report = RunReport::new("run-001", start);
+        report.add_event(TimelineEvent::RunStarted {
+            timestamp: Timestamp::now(),
+            task_id: TaskId::new(),
+        });
+        report.complete(OutcomeStatus::Success, Timestamp::now());
+
+        let display = report.to_string();
+
+        assert!(display.contains("run-001"));
+        assert!(display.contains("success"));
+        assert!(display.contains("duration"));
+        assert!(display.contains("events=1"));
+    }
+
+    #[test]
+    fn run_report_validate_success() {
+        let report = RunReport::new("run-001", Timestamp::now());
+        assert!(report.validate().is_ok());
+    }
+
+    #[test]
+    fn run_report_validate_empty_run_id() {
+        let report = RunReport::new("", Timestamp::now());
+        let result = report.validate();
+
+        assert!(result.is_err());
+
+        let Err(AstraError::ValidationFailed { context, .. }) = result else {
+            panic!("expected ValidationFailed");
+        };
+        assert_eq!(context.error_code, "VAL-084");
+    }
+
+    #[test]
+    fn run_report_validate_whitespace_run_id() {
+        let report = RunReport::new("   ", Timestamp::now());
+        let result = report.validate();
+
+        assert!(result.is_err());
+
+        let Err(AstraError::ValidationFailed { context, .. }) = result else {
+            panic!("expected ValidationFailed");
+        };
+        assert_eq!(context.error_code, "VAL-084");
+    }
+
+    #[test]
+    fn run_report_validate_started_after_completed() {
+        let now = Timestamp::now();
+        let earlier = Timestamp::from(Utc::now() - Duration::hours(1));
+
+        let mut report = RunReport::new("run-001", now);
+        report.completed_at = Some(earlier);
+
+        let result = report.validate();
+        assert!(result.is_err());
+
+        let Err(AstraError::ValidationFailed { context, .. }) = result else {
+            panic!("expected ValidationFailed");
+        };
+        assert_eq!(context.error_code, "VAL-085");
+    }
+
+    #[test]
+    fn run_report_validate_same_start_end_ok() {
+        let ts = Timestamp::now();
+        let mut report = RunReport::new("run-001", ts.clone());
+        report.completed_at = Some(ts);
+
+        assert!(report.validate().is_ok());
+    }
+
+    #[test]
+    fn run_report_serde_roundtrip() {
+        let mut report = RunReport::new("run-001", Timestamp::now());
+        report.add_event(TimelineEvent::RunStarted {
+            timestamp: Timestamp::now(),
+            task_id: TaskId::new(),
+        });
+        report.add_artifact(ArtifactId::new());
+        report.add_policy_decision(DecisionId::new());
+        report.add_intervention(Intervention::Pause {
+            timestamp: Timestamp::now(),
+            reason: "Test".into(),
+        });
+        report.add_agent("agent-001");
+        report.set_budgets(BudgetSnapshot::new(Budget::default()));
+        report.complete(OutcomeStatus::Success, Timestamp::now());
+
+        let Ok(json) = serde_json::to_string(&report) else {
+            panic!("serialization should succeed");
+        };
+        let Ok(decoded) = serde_json::from_str::<RunReport>(&json) else {
+            panic!("deserialization should succeed");
+        };
+
+        assert_eq!(report.run_id, decoded.run_id);
+        assert_eq!(report.status, decoded.status);
+        assert_eq!(report.timeline.len(), decoded.timeline.len());
+        assert_eq!(report.artifacts.len(), decoded.artifacts.len());
+        assert_eq!(
+            report.policy_decisions.len(),
+            decoded.policy_decisions.len()
+        );
+        assert_eq!(report.interventions.len(), decoded.interventions.len());
+        assert_eq!(report.agents.len(), decoded.agents.len());
+    }
+
+    #[test]
+    fn run_report_serde_skips_empty_collections() {
+        let report = RunReport::new("run-001", Timestamp::now());
+
+        let Ok(json) = serde_json::to_string(&report) else {
+            panic!("serialization should succeed");
+        };
+
+        assert!(!json.contains("\"artifacts\""));
+        assert!(!json.contains("\"policy_decisions\""));
+        assert!(!json.contains("\"interventions\""));
+        assert!(!json.contains("\"agents\""));
+    }
+
+    #[test]
+    fn run_report_serde_skips_none_fields() {
+        let report = RunReport::new("run-001", Timestamp::now());
+
+        let Ok(json) = serde_json::to_string(&report) else {
+            panic!("serialization should succeed");
+        };
+
+        assert!(!json.contains("\"completed_at\""));
+        assert!(!json.contains("\"error\""));
+    }
+}


### PR DESCRIPTION
## <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Policy decision tracking system with audit-ready evaluations, supporting Allow/Deny/Escalate effects and compliance metadata.
  * Run report system capturing comprehensive workflow execution data including timeline events, resource budgets, and operator interventions.
  * Decision identifier type for policy audit trail tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Implements Issue #9: Define PolicyDecision and RunReport schemas for the astra-types crate.

## Changes

### New Types in `policy.rs`
- **PolicyEffect** - Enum with Allow/Deny/Escalate variants and helper methods (`is_allowed()`, `is_denied()`, `requires_escalation()`)
- **PolicyLevel** - Enum representing policy hierarchy (Global < Domain < Capability < Session) with `overrides()` method
- **PolicySource** - Struct for rule provenance (rule_id, level, optional path)
- **PolicyDecision** - Full policy decision record with constructors (`allow()`, `deny()`, `escalate()`) and builder pattern

### New Types in `report.rs`
- **TimelineEvent** - Tagged enum with 10 event types (RunStarted, AgentSpawned, TaskDispatched, CapabilityInvoked, ModelCalled, PolicyEvaluated, ArtifactMutated, AgentCompleted, RunCompleted, ErrorOccurred)
- **Intervention** - Tagged enum with 5 intervention types (Pause, Resume, Kill, BudgetGrant, PolicyOverride)
- **BudgetSnapshot** - Budget tracking with `Default` returning zeros (not Budget's non-zero defaults)
- **RunReport** - Full run report with timeline, artifacts, budgets, policy decisions, interventions, and helpers (`duration_ms()`, `is_success()`, `is_failure()`, `complete()`)

### Updated Files
- **id.rs** - Added `DecisionId` UUID type
- **lib.rs** - Added module declarations and exports
- **prelude.rs** - Added exports for new types

## Validation Rules
- **VAL-080**: PolicySource.rule_id cannot be empty
- **VAL-081**: PolicyDecision.action cannot be empty
- **VAL-082**: PolicyDecision.requester cannot be empty
- **VAL-083**: PolicyDecision.reason cannot be empty for Deny/Escalate effects
- **VAL-084**: RunReport.run_id cannot be empty
- **VAL-085**: RunReport.started_at must not be after completed_at

## Design Decisions
1. **Auto-generated IDs/timestamps** - Constructors auto-generate `id` and `timestamp` (matches Artifact/ContextItem pattern)
2. **DecisionId as UUID** - Consistent with TaskId, ArtifactId, ContextId
3. **run_id/agent_id as String** - No RunId/AgentId types defined yet
4. **BudgetSnapshot::default() returns zeros** - Distinguishes from Budget::default() which has non-zero values
5. **duration_ms() uses millisecond arithmetic** - Returns `Option<i64>` for completed reports
6. **VAL-085 allows equal timestamps** - Supports instant runs within same millisecond

## Testing
- ~45 tests in policy.rs
- ~55 tests in report.rs
- All 500 astra-types tests pass
- Full quality gate passed (fmt, clippy, test)

## Checklist
- [x] Code compiles without warnings
- [x] All tests pass (500 tests)
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes with `-D warnings`
- [x] Documentation included

Closes #9